### PR TITLE
#35

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,7 @@ test:
 	mkdir -p src/static
 	cd src && ./manage.py makemigrations --dry-run --no-input --check
 	cd src && ./manage.py compilemessages
-	# doesn't really work with lazy-fixtures
-	# pytest --dead-fixtures
-	pytest -x -n auto
+	pytest -x -n auto --unused-fixtures --unused-fixtures-ignore-path=venv
 
 server:
 	cd src && python manage.py runserver

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -282,7 +282,7 @@ pyjwt[crypto]==2.8.0
     #   social-auth-core
 pytest==7.4.3
     # via
-    #   pytest-deadfixtures
+    #   pytest-unused-fixtures
     #   pytest-django
     #   pytest-env
     #   pytest-freezegun
@@ -290,7 +290,7 @@ pytest==7.4.3
     #   pytest-mock
     #   pytest-randomly
     #   pytest-xdist
-pytest-deadfixtures==2.2.1
+pytest-unused-fixtures==0.1.4
     # via bbq (pyproject.toml)
 pytest-django==4.7.0
     # via bbq (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "ipython",
 
     "pytest-django>=3.9",
-    "pytest-deadfixtures",
+    "pytest-unused-fixtures",
     "pytest-env",
     "pytest-freezegun",
     "pytest-mock",

--- a/tests/fixtures/apps/companies/employee.py
+++ b/tests/fixtures/apps/companies/employee.py
@@ -46,6 +46,7 @@ def employee_with_non_existing_department(factory: FixtureFactory) -> EmployeeDa
     params=[
         lf("employee_with_duplicating_department"),
         lf("employee_with_non_existing_user"),
+        lf("employee_with_non_existing_department"),
     ]
 )
 def employee_invalid_data(request: pytest.FixtureRequest) -> dict:

--- a/tests/fixtures/apps/purchases/__init__.py
+++ b/tests/fixtures/apps/purchases/__init__.py
@@ -6,8 +6,6 @@ from tests.fixtures.apps.purchases.purchase_procedure import (
     purchase_procedure_with_one_material,
 )
 from tests.fixtures.apps.purchases.used_material import (
-    used_material,
-    used_material_data,
     used_materials_data_without_procedure,
     used_materials_data_without_procedure_and_not_unique,
 )
@@ -20,8 +18,6 @@ __all__ = [
     "purchase_procedure",
     "purchase_procedure_data",
     "purchase_procedure_with_one_material",
-    "used_material",
-    "used_material_data",
     "used_materials_data_without_procedure",
     "used_materials_data_without_procedure_and_not_unique",
 ]

--- a/tests/fixtures/apps/purchases/used_material.py
+++ b/tests/fixtures/apps/purchases/used_material.py
@@ -2,22 +2,7 @@ import pytest
 
 from app.testing.factory import FixtureFactory
 from companies.models import StockMaterial
-from purchases.models import PurchaseProcedure, UsedMaterial
 from purchases.types import UsedMaterialData
-
-
-@pytest.fixture
-def used_material_data(
-    factory: FixtureFactory, purchase_procedure: PurchaseProcedure, stock_material: StockMaterial
-) -> UsedMaterialData:
-    return factory.used_material_data(procedure=purchase_procedure.procedure, material=stock_material)
-
-
-@pytest.fixture
-def used_material(
-    factory: FixtureFactory, purchase_procedure: PurchaseProcedure, stock_material: StockMaterial
-) -> UsedMaterial:
-    return factory.used_material(procedure=purchase_procedure.procedure, material=stock_material)
 
 
 @pytest.fixture

--- a/tests/fixtures/apps/users.py
+++ b/tests/fixtures/apps/users.py
@@ -10,18 +10,5 @@ def user(factory: "FixtureFactory") -> User:
 
 
 @pytest.fixture
-def another_user(factory: "FixtureFactory") -> User:
-    return factory.user()
-
-
-@pytest.fixture
 def superuser(factory: "FixtureFactory") -> User:
     return factory.superuser()
-
-
-@pytest.fixture
-def another_user_id(another_user: User) -> int:
-    """
-    This is usefull for testing endpoints, which handle serializers with owner/author fields.
-    """
-    return another_user.pk


### PR DESCRIPTION
We had 6 unused fixtures:
1. `api -- tests/apps/app/test_remote_addr_midlleware.py:22` - skip("don't sure we need this.");
2. `used_material_data -- tests/fixtures/apps/purchases/used_material.py:9` - It was not needed for our test logic;
3. `used_material -- tests/fixtures/apps/purchases/used_material.py:16` - It's the same;
4. `another_user -- tests/fixtures/apps/users.py:12` - This is a redundant fixture;
5. `another_user_id -- tests/fixtures/apps/users.py:22` - It's the same;
6. `employee_with_non_existing_department -- tests/fixtures/apps/companies/employee.py:40` - Added to the test.